### PR TITLE
Added gccgo support to testAll

### DIFF
--- a/testAll.sh
+++ b/testAll.sh
@@ -6,5 +6,10 @@ CONF_FILE="$HOME/nerdz_env/confSample.json"
 
 for i in $(find . -name '*_test.go'); do
     echo $i
-    CONF_FILE=$CONF_FILE ENABLE_LOG=$ENABLE_LOG go test $i $@
+    echo 'Using gc:'
+    CONF_FILE=$CONF_FILE ENABLE_LOG=$ENABLE_LOG go test -compiler gc $i $@
+    if hash gccgo 2>/dev/null; then
+      echo 'Using gccgo:'
+      CONF_FILE=$CONF_FILE ENABLE_LOG=$ENABLE_LOG go test -compiler gccgo $i $@
+    fi
 done


### PR DESCRIPTION
With this PR, testAll.sh tests with both gc and gccgo (if the latter is present).

This makes development for both compilers easier, and makes code less implementation dependent.
