### PR TITLE
wrap websocket.Handler with websocket.Server for notifications stream

### DIFF
--- a/stream/notifications.go
+++ b/stream/notifications.go
@@ -35,7 +35,7 @@ func Notifications() echo.HandlerFunc {
 			return c.String(http.StatusInternalServerError, "Invalid authorization")
 		}
 
-		websocket.Handler(func(ws *websocket.Conn) {
+		websocket.Server{Handler: websocket.Handler(func(ws *websocket.Conn) {
 			// Listen from notification sent on DB channel u<ID>
 			nerdz.Db().Listen("u"+strconv.Itoa(int(accessData.UserData.(uint64))), func(payload ...string) {
 				if len(payload) == 1 {
@@ -53,7 +53,7 @@ func Notifications() echo.HandlerFunc {
 					break
 				}
 			}
-		}).ServeHTTP(c.Response(), c.Request())
+		})}.ServeHTTP(c.Response(), c.Request())
 		return nil
 	}
 }


### PR DESCRIPTION
This is needed for using the api from non-browser client, as stated on the official doc here https://godoc.org/golang.org/x/net/websocket#Handler